### PR TITLE
Clarified nth vs index

### DIFF
--- a/test/Chekote/NounStore/Store/AssertKeyExistsTest.php
+++ b/test/Chekote/NounStore/Store/AssertKeyExistsTest.php
@@ -8,7 +8,7 @@ use OutOfBoundsException;
  */
 class AssertKeyExistsTest extends StoreTest
 {
-    public function testMismatchedNthInKeyAndParamAreRejected()
+    public function testMismatchedNthAndIndexAreRejected()
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -31,13 +31,13 @@ class AssertKeyExistsTest extends StoreTest
         $this->store->assertKeyExists('3rd ' . self::KEY);
     }
 
-    public function testExistingNthParameterReturnsValue()
+    public function testExistingIndexReturnsValue()
     {
         /* @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(self::FIRST_VALUE, $this->store->assertKeyExists(self::KEY, 0));
     }
 
-    public function testNonExistentNthParameterThrowsException()
+    public function testNonExistentIndexThrowsException()
     {
         $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage("Entry '3rd " . self::KEY . "' was not found in the store.");

--- a/test/Chekote/NounStore/Store/GetTest.php
+++ b/test/Chekote/NounStore/Store/GetTest.php
@@ -8,10 +8,10 @@ use InvalidArgumentException;
 class GetTest extends StoreTest
 {
     /**
-     * Tests that InvalidArgumentException is thrown if Store::get is called with the nth parameter
+     * Tests that InvalidArgumentException is thrown if Store::get is called with the index parameter
      * and the key also contains an nth value, but they do not match.
      */
-    public function testGetThrowsInvalidArgumentExceptionWithMismatchedNthInKeyAndParam()
+    public function testGetThrowsInvalidArgumentExceptionWithMismatchedNthAndIndex()
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -35,9 +35,9 @@ class GetTest extends StoreTest
     }
 
     /**
-     * Tests that Store::get returns the nth item at of the stack when $nth parameter is provided.
+     * Tests that Store::get returns the index item at of the stack when index parameter is provided.
      */
-    public function testGetWithNthParameterReturnsNthItem()
+    public function testGetWithIndexParameterReturnsIndexItem()
     {
         $this->assertEquals(self::FIRST_VALUE, $this->store->get(self::KEY, 0));
     }
@@ -59,9 +59,9 @@ class GetTest extends StoreTest
     }
 
     /**
-     * Tests that Store::get returns null when the specified $nth param does not exist.
+     * Tests that Store::get returns null when the specified $index param does not exist.
      */
-    public function testGetReturnsNullWhenNthDoesNotExist()
+    public function testGetReturnsNullWhenIndexDoesNotExist()
     {
         $this->assertEquals(null, $this->store->get(self::KEY, 2));
     }

--- a/test/Chekote/NounStore/Store/KeyExistsTest.php
+++ b/test/Chekote/NounStore/Store/KeyExistsTest.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
  */
 class KeyExistsTest extends StoreTest
 {
-    public function testMismatchedNthInKeyAndParamThrowsInvalidArgumentException()
+    public function testMismatchedNthAndIndexThrowsInvalidArgumentException()
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -24,12 +24,12 @@ class KeyExistsTest extends StoreTest
         $this->assertFalse($this->store->keyExists('3rd ' . self::KEY));
     }
 
-    public function testExistingNthParameterReturnsTrue()
+    public function testExistingIndexParameterReturnsTrue()
     {
         $this->assertTrue($this->store->keyExists(self::KEY, 0));
     }
 
-    public function testMissingNthParameterReturnFalse()
+    public function testMissingIndexParameterReturnFalse()
     {
         $this->assertFalse($this->store->keyExists(self::KEY, 2));
     }

--- a/test/Chekote/NounStore/Store/ParseKeyTest.php
+++ b/test/Chekote/NounStore/Store/ParseKeyTest.php
@@ -10,52 +10,52 @@ use ReflectionClass;
 class ParseKeyTest extends StoreTest
 {
     /**
-     * Provides examples of valid key and nth pairs with expected parse results.
+     * Provides examples of valid key and index pairs with expected parse results.
      *
      * @return array
      */
-    public function validKeyAndNthCombinationsDataProvider()
+    public function validKeyAndIndexCombinationsDataProvider()
     {
         return [
-        //   key             nth   parseKey parseNth
-            ['Thing',       null, 'Thing',     null], // no nth in key or nth param
-            ['1st Thing',   null, 'Thing',        0], // 1st in key with no nth param
-            ['1st Thing',      0, 'Thing',        0], // nth in key with matching nth param
-            ['2nd Thing',   null, 'Thing',        1], // 2nd in key with no nth param
-            ['3rd Thing',   null, 'Thing',        2], // 3rd in key with no nth param
-            ['4th Thing',   null, 'Thing',        3], // 3th in key with no nth param
-            ['478th Thing', null, 'Thing',      477], // high nth in key with no nth param
-            ['Thing',          0, 'Thing',        0], // no nth in key with 0 nth param
-            ['Thing',         49, 'Thing',       49], // no nth in key with high nth param
+        //   key           index   parseKey parseIndex
+            ['Thing',       null, 'Thing',     null], // no nth in key or index param
+            ['1st Thing',   null, 'Thing',        0], // 1st in key with no index param
+            ['1st Thing',      0, 'Thing',        0], // nth in key with matching index param
+            ['2nd Thing',   null, 'Thing',        1], // 2nd in key with no index param
+            ['3rd Thing',   null, 'Thing',        2], // 3rd in key with no index param
+            ['4th Thing',   null, 'Thing',        3], // 3th in key with no index param
+            ['478th Thing', null, 'Thing',      477], // high nth in key with no index param
+            ['Thing',          0, 'Thing',        0], // no nth in key with 0 index param
+            ['Thing',         49, 'Thing',       49], // no nth in key with high index param
         ];
     }
 
     /**
-     * Tests that calling Store::parseKey with valid key and nth combinations works correctly.
+     * Tests that calling Store::parseKey with valid key and index combinations works correctly.
      *
-     * @dataProvider validKeyAndNthCombinationsDataProvider
-     * @param string $key       the key to parse
-     * @param int    $nth       the nth to pass along with the key
-     * @param string $parsedKey the expected resulting parsed key
-     * @param int    $parsedNth the expected resulting parsed nth
+     * @dataProvider validKeyAndIndexCombinationsDataProvider
+     * @param string $key         the key to parse
+     * @param int    $index       the index to pass along with the key
+     * @param string $parsedKey   the expected resulting parsed key
+     * @param int    $parsedIndex the expected resulting parsed index
      */
-    public function testParseKeyParsesValidKeysAndNthCombinations($key, $nth, $parsedKey, $parsedNth)
+    public function testParseKeyParsesValidKeysAndNthCombinations($key, $index, $parsedKey, $parsedIndex)
     {
         $parseKey = (new ReflectionClass(Store::class))->getMethod('parseKey');
         $parseKey->setAccessible(true);
 
-        list($actualKey, $actualNth) = $parseKey->invoke($this->store, $key, $nth);
+        list($actualKey, $actualIndex) = $parseKey->invoke($this->store, $key, $index);
 
         $this->assertEquals($parsedKey, $actualKey);
-        $this->assertEquals($parsedNth, $actualNth);
+        $this->assertEquals($parsedIndex, $actualIndex);
     }
 
     /**
-     * Provides examples of mismatched key & nth pairs.
+     * Provides examples of mismatched key & index pairs.
      *
      * @return array
      */
-    public function mismatchedKeyAndNthDataProvider()
+    public function mismatchedKeyAndIndexDataProvider()
     {
         return [
             ['1st Thing', 1],
@@ -67,22 +67,22 @@ class ParseKeyTest extends StoreTest
     }
 
     /**
-     * Tests that calling Store::parseKey with mismatched key and nth param throws an exception.
+     * Tests that calling Store::parseKey with mismatched key and index param throws an exception.
      *
-     * @dataProvider mismatchedKeyAndNthDataProvider
-     * @param string $key the key to parse
-     * @param string $nth the mismatched nth to pass along with the key
+     * @dataProvider mismatchedKeyAndIndexDataProvider
+     * @param string $key   the key to parse
+     * @param string $index the mismatched index to pass along with the key
      */
-    public function testParseKeyThrowsExceptionIfKeyAndNthMismatch($key, $nth)
+    public function testParseKeyThrowsExceptionIfKeyAndIndexMismatch($key, $index)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            "$nth was provided for nth param when key '$key' contains an nth value, but they do not match"
+            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
         );
 
         $parseKey = (new ReflectionClass(Store::class))->getMethod('parseKey');
         $parseKey->setAccessible(true);
 
-        $parseKey->invoke($this->store, $key, $nth);
+        $parseKey->invoke($this->store, $key, $index);
     }
 }


### PR DESCRIPTION
Renamed nth param to index and updated documentation to clarify difference between the nth string in the key vs the index parameter.