### PR TITLE
Optimize Assert::keyValueIs method

### DIFF
--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -93,9 +93,7 @@ class Assert
     {
         list($key, $index) = $this->keyService->parse($key, $index);
 
-        $this->keyExists($key, $index);
-
-        if ($this->store->get($key, $index) != $value) {
+        if ($this->keyExists($key, $index) != $value) {
             throw new RuntimeException(
                 "Entry '" . $this->keyService->build($key, $index) . "' does not match '" . print_r($value, true) . "'"
             );

--- a/test/Chekote/NounStore/Assert/KeyValueIsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyValueIsTest.php
@@ -29,8 +29,7 @@ class KeyValueIsTest extends AssertTest
         /* @noinspection PhpUndefinedMethodInspection */
         {
             Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(null);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn($value);
+            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn($value);
         }
 
         $this->assert->keyValueIs($key, $value, $index);
@@ -87,8 +86,7 @@ class KeyValueIsTest extends AssertTest
         /* @noinspection PhpUndefinedMethodInspection */
         {
             Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(null);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn('Some Other Value');
+            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn('Some Other Value');
             Phake::expect($this->key, 1)->build($parsedKey, $parsedIndex)->thenReturn($key);
         }
 
@@ -109,8 +107,7 @@ class KeyValueIsTest extends AssertTest
         /* @noinspection PhpUndefinedMethodInspection */
         {
             Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(null);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn($value);
+            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn($value);
         }
 
         $this->assert->keyValueIs($key, $value, $index);


### PR DESCRIPTION
# Problem:
The keyValueIs() method is calling keyExists(), then get() if it exists. This is unecessary since keyExists() returns the value if it exists.

# Fix:
I removed the get() call and moved the keyExists() call to where the get() call was.