### PR TITLE
Drop support for index args.

### DIFF
--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -35,10 +35,10 @@ class Assert
      *
      * @see    Key::build()
      * @see    Key::parse()
-     * @param  string                   $key   The key to check. Supports nth notation.
+     * @param  string                   $key The key to check. Supports nth notation.
      * @throws OutOfBoundsException     if a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
-     *                                        that does not match the index.
+     *                                      that does not match the index.
      * @return mixed                    The value.
      */
     public function keyExists($key)

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -33,25 +33,21 @@ class Assert
     /**
      * Asserts that a value has been stored for the specified key.
      *
-     * @param  string                   $key   The key to check. @see self::get() for formatting options.
-     * @param  int                      $index [optional] The index of the key entry to check. If not specified, the
-     *                                         method will ensure that at least one item is stored for the key.
+     * @see    Key::build()
+     * @see    Key::parse()
+     * @param  string                   $key   The key to check. Supports nth notation.
      * @throws OutOfBoundsException     if a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
      *                                        that does not match the index.
      * @return mixed                    The value.
      */
-    public function keyExists($key, $index = null)
+    public function keyExists($key)
     {
-        list($key, $index) = $this->keyService->parse($key, $index);
-
-        if (!$this->store->keyExists($key, $index)) {
-            throw new OutOfBoundsException(
-                "Entry '" . $this->keyService->build($key, $index) . "' was not found in the store."
-            );
+        if (!$this->store->keyExists($key)) {
+            throw new OutOfBoundsException("Entry '$key' was not found in the store.");
         }
 
-        return $this->store->get($key, $index);
+        return $this->store->get($key);
     }
 
     /**

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -73,22 +73,18 @@ class Assert
     /**
      * Asserts that the key's value matches the specified value.
      *
-     * @param  string                   $key   The key to check. @see self::get() for formatting options.
+     * @see    Key::build()
+     * @see    Key::parse()
+     * @param  string                   $key   The key to check. Supports nth notation.
      * @param  mixed                    $value The expected value.
-     * @param  int                      $index [optional] The index of the key entry to retrieve. If not specified, the
-     *                                         method will check the most recent value stored under the key.
      * @throws OutOfBoundsException     If a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
      *                                        that does not match the index.
      */
-    public function keyValueIs($key, $value, $index = null)
+    public function keyValueIs($key, $value)
     {
-        list($key, $index) = $this->keyService->parse($key, $index);
-
-        if ($this->keyExists($key, $index) != $value) {
-            throw new RuntimeException(
-                "Entry '" . $this->keyService->build($key, $index) . "' does not match '" . print_r($value, true) . "'"
-            );
+        if ($this->keyExists($key) != $value) {
+            throw new RuntimeException("Entry '$key' does not match '" . print_r($value, true) . "'");
         }
     }
 }

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -53,24 +53,20 @@ class Assert
     /**
      * Asserts that the key's value contains the specified string.
      *
-     * @param  string                   $key   The key to check. @see self::get() for formatting options.
+     * @see    Key::build()
+     * @see    Key::parse()
+     * @param  string                   $key   The key to check. Supports nth notation.
      * @param  string                   $value The value expected to be contained within the key's value.
-     * @param  int                      $index [optional] The index of the key entry to retrieve. If not specified, the
-     *                                         method will check the most recent value stored under the key.
      * @throws OutOfBoundsException     If a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
      *                                        that does not match the index.
      */
-    public function keyValueContains($key, $value, $index = null)
+    public function keyValueContains($key, $value)
     {
-        list($key, $index) = $this->keyService->parse($key, $index);
+        $this->keyExists($key);
 
-        $this->keyExists($key, $index);
-
-        if (!$this->store->keyValueContains($key, $value, $index)) {
-            throw new RuntimeException(
-                "Entry '" . $this->keyService->build($key, $index) . "' does not contain '$value'"
-            );
+        if (!$this->store->keyValueContains($key, $value)) {
+            throw new RuntimeException("Entry '$key' does not contain '$value'");
         }
     }
 

--- a/src/Chekote/NounStore/Key.php
+++ b/src/Chekote/NounStore/Key.php
@@ -70,30 +70,24 @@ class Key
      * Parses a key into the separate key and index value.
      *
      * @example parseKey("Item"): ["Item", null]
-     * @example parseKey("Item", 1): ["Item", 1]
      * @example parseKey("1st Item"): ["Item", 0]
      * @example parseKey("2nd Item"): ["Item", 1]
      * @example parseKey("3rd Item"): ["Item", 2]
      *
      * @param  string                   $key   the key to parse.
-     * @param  int                      $index [optional] the index to return if the key does not contain one.
-     * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
-     *                                        that does not match the index.
+     * @throws InvalidArgumentException if the key syntax is invalid.
      * @return array                    a tuple, the 1st being the key with the nth removed, and the 2nd being the
-     *                                        index.
+     *                                        index that the nth translates to, or null if no nth was specified.
      */
-    public function parse($key, $index = null)
+    public function parse($key)
     {
-        if (preg_match('/^([1-9][0-9]*)(?:st|nd|rd|th) (.+)$/', $key, $matches)) {
-            if ($index !== null && $index != $matches[1] - 1) {
-                throw new InvalidArgumentException(
-                    "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-                );
-            }
-
-            $index = $matches[1] - 1;
-            $key = $matches[2];
+        if (!preg_match("/^(([1-9][0-9]*)(?:st|nd|rd|th) )?([^']+)$/", $key, $matches)) {
+            throw new InvalidArgumentException('Key syntax is invalid');
         }
+
+        // @todo use null coalescing operator when upgrading to PHP 7
+        $index = isset($matches[2]) && $matches[2] !== '' ? $matches[2] - 1 : null;
+        $key = $matches[3];
 
         return [$key, $index];
     }

--- a/src/Chekote/NounStore/Key.php
+++ b/src/Chekote/NounStore/Key.php
@@ -74,10 +74,10 @@ class Key
      * @example parseKey("2nd Item"): ["Item", 1]
      * @example parseKey("3rd Item"): ["Item", 2]
      *
-     * @param  string                   $key   the key to parse.
+     * @param  string                   $key the key to parse.
      * @throws InvalidArgumentException if the key syntax is invalid.
      * @return array                    a tuple, the 1st being the key with the nth removed, and the 2nd being the
-     *                                        index that the nth translates to, or null if no nth was specified.
+     *                                      index that the nth translates to, or null if no nth was specified.
      */
     public function parse($key)
     {

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -98,19 +98,16 @@ class Store
     /**
      * Asserts that the key's value contains the specified string.
      *
-     * @param  string                   $key   The key to check. @see self::get() for formatting options.
+     * @see    Key::build()
+     * @see    Key::parse()
+     * @param  string                   $key   The key to check.
      * @param  string                   $value The value expected to be contained within the key's value.
-     * @param  int                      $index [optional] The index of the key entry to retrieve. If not specified, the
-     *                                         method will check the most recent value stored under the key.
-     * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
-     *                                        that does not match the index.
+     * @throws InvalidArgumentException if the key syntax is invalid.
      * @return bool                     True if the key's value contains the specified string, false if not.
      */
-    public function keyValueContains($key, $value, $index = null)
+    public function keyValueContains($key, $value)
     {
-        list($key, $index) = $this->keyService->parse($key, $index);
-
-        $actual = $this->get($key, $index);
+        $actual = $this->get($key);
 
         return is_string($actual) && strpos($actual, $value) !== false;
     }

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -94,16 +94,15 @@ class Store
     /**
      * Determines if a value has been stored for the specified key.
      *
+     * @see    Key::build()
+     * @see    Key::parse()
      * @param  string                   $key   The key to check.
-     * @param  int                      $index [optional] The index of the key entry to check. If not specified, the
-     *                                         method will ensure that at least one item is stored for the key.
-     * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
-     *                                        that does not match the index.
+     * @throws InvalidArgumentException if the key syntax is invalid.
      * @return bool                     True if the a value has been stored, false if not.
      */
-    public function keyExists($key, $index = null)
+    public function keyExists($key)
     {
-        list($key, $index) = $this->keyService->parse($key, $index);
+        list($key, $index) = $this->keyService->parse($key);
 
         return $index !== null ? isset($this->nouns[$key][$index]) : isset($this->nouns[$key]);
     }

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -48,7 +48,7 @@ class Store
      *
      * @see    Key::build()
      * @see    Key::parse()
-     * @param  string                   $key The key to retrieve the value for. Can be prefixed with an nth descriptor.
+     * @param  string                   $key The key to retrieve the value for. Supports nth notation.
      * @throws InvalidArgumentException if the key syntax is invalid.
      * @return mixed                    The value, or null if no value exists for the specified key/index combination.
      */
@@ -66,7 +66,7 @@ class Store
     /**
      * Retrieves all values for the specified key.
      *
-     * @param  string               $key The key to retrieve the values for.
+     * @param  string               $key The key to retrieve the values for. Does not support nth notation.
      * @throws OutOfBoundsException if the specified $key does not exist in the store.
      * @return array                The values.
      */
@@ -84,7 +84,7 @@ class Store
      *
      * @see    Key::build()
      * @see    Key::parse()
-     * @param  string                   $key   The key to check.
+     * @param  string                   $key   The key to check. Supports nth notation.
      * @throws InvalidArgumentException if the key syntax is invalid.
      * @return bool                     True if the a value has been stored, false if not.
      */
@@ -115,7 +115,7 @@ class Store
     /**
      * Stores a value for the specified key.
      *
-     * @param string $key   The key to store the value under.
+     * @param string $key   The key to store the value under. Does not support nth notation.
      * @param mixed  $value The value to store.
      */
     public function set($key, $value)

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -55,7 +55,7 @@ class Store
     public function get($key)
     {
         if (!$this->keyExists($key)) {
-            return null;
+            return;
         }
 
         list($key, $index) = $this->keyService->parse($key);
@@ -84,7 +84,7 @@ class Store
      *
      * @see    Key::build()
      * @see    Key::parse()
-     * @param  string                   $key   The key to check. Supports nth notation.
+     * @param  string                   $key The key to check. Supports nth notation.
      * @throws InvalidArgumentException if the key syntax is invalid.
      * @return bool                     True if the a value has been stored, false if not.
      */

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -115,6 +115,8 @@ class Store
     /**
      * Stores a value for the specified key.
      *
+     * The specified value is added to the top of the "stack" for the specified key.
+     *
      * @param string $key   The key to store the value under. Does not support nth notation.
      * @param mixed  $value The value to store.
      */

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -34,43 +34,31 @@ class Store
      * Retrieves a value for the specified key.
      *
      * Each key is actually a collection. If you do not specify which item in the collection you want,
-     * the method will return the most recent entry. You can specify the entry you want by either
-     * using the plain english 1st, 2nd, 3rd etc in the $key param, or by specifying 0, 1, 2 etc in
-     * the $index param. For example:
+     * the method will return the most recent entry. You can optionally specify the entry you want by
+     * using the plain english 1st, 2nd, 3rd etc in the $key param. For example:
      *
      * Retrieve the most recent entry "Thing" collection:
      *   retrieve("Thing")
      *
      * Retrieve the 1st entry in the "Thing" collection:
      *   retrieve("1st Thing")
-     *   retrieve("Thing", 0)
      *
      * Retrieve the 3rd entry in the "Thing" collection:
      *   retrieve("3rd Thing")
-     *   retrieve("Thing", 2)
      *
-     * Please note: The nth value in the string key is indexed from 1. In that "1st" is the first item stored.
-     * The index parameter is indexed from 0. In that 0 is the first item stored.
-     *
-     * Please Note: If you specify both an $index param and an nth in the $key, they must both reference the same index.
-     * If they do not, the method will throw an InvalidArgumentException.
-     *
-     * retrieve("1st Thing", 1);
-     *
-     * @param  string                   $key   The key to retrieve the value for. Can be prefixed with an nth descriptor.
-     * @param  int                      $index [optional] The index of the key entry to retrieve. If not specified, the
-     *                                         method will return the most recent value stored under the key.
-     * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
-     *                                        that does not match the index.
+     * @see    Key::build()
+     * @see    Key::parse()
+     * @param  string                   $key The key to retrieve the value for. Can be prefixed with an nth descriptor.
+     * @throws InvalidArgumentException if the key syntax is invalid.
      * @return mixed                    The value, or null if no value exists for the specified key/index combination.
      */
-    public function get($key, $index = null)
+    public function get($key)
     {
-        list($key, $index) = $this->keyService->parse($key, $index);
-
-        if (!$this->keyExists($key, $index)) {
-            return;
+        if (!$this->keyExists($key)) {
+            return null;
         }
+
+        list($key, $index) = $this->keyService->parse($key);
 
         return $index !== null ? $this->nouns[$key][$index] : end($this->nouns[$key]);
     }

--- a/test/Chekote/NounStore/Assert/KeyExistsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyExistsTest.php
@@ -20,74 +20,75 @@ class KeyExistsTest extends AssertTest
     public function testKeyIsParsedAndParsedValuesAreUsed()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(true);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn('something');
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->store, 1)->get($key)->thenReturn('something');
         }
 
-        $this->assert->keyExists($key, $index);
+        $this->assert->keyExists($key);
     }
 
-    public function testInvalidArgumentExceptionBubblesUpFromParse()
+    public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
-        $key = '10th Thing';
-        $index = 5;
-        $exception = new InvalidArgumentException(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
+        $key = "An invalid key";
+        $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenThrow($exception);
+        Phake::expect($this->store, 1)->keyExists($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyExists($key, $index);
+        $this->assert->keyExists($key);
+    }
+
+    // An invalid key should not get past keyExists(), so this should never actually be possible. But we test
+    // the behavior here to ensure that our method behaves correctly should the impossible ever occur.
+    public function testInvalidArgumentExceptionBubblesUpFromGet()
+    {
+        $key = "An invalid key";
+        $exception = new InvalidArgumentException('Key syntax is invalid');
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        {
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->store, 1)->get($key)->thenThrow($exception);
+        }
+
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+
+        $this->assert->keyExists($key);
     }
 
     public function testMissingKeyThrowsOutOfBoundsException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
 
         $exception = new OutOfBoundsException("Entry '$key' was not found in the store.");
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(false);
-            Phake::expect($this->key, 1)->build($parsedKey, $parsedIndex)->thenReturn($key);
-        }
+        Phake::expect($this->store, 1)->keyExists($key)->thenReturn(false);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyExists($key, $index);
+        $this->assert->keyExists($key);
     }
 
     public function testStoredValueIsReturned()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(true);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn($value);
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->store, 1)->get($key)->thenReturn($value);
         }
 
-        $this->assertEquals($value, $this->assert->keyExists($key, $index));
+        $this->assertEquals($value, $this->assert->keyExists($key));
     }
 }

--- a/test/Chekote/NounStore/Assert/KeyExistsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyExistsTest.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore\Assert;
 
+use Chekote\NounStore\Key\KeyTest;
 use Chekote\Phake\Phake;
 use InvalidArgumentException;
 use OutOfBoundsException;
@@ -32,35 +33,33 @@ class KeyExistsTest extends AssertTest
 
     public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
-        $key = "An invalid key";
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->store, 1)->keyExists($key)->thenThrow($exception);
+        Phake::expect($this->store, 1)->keyExists(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyExists($key);
+        $this->assert->keyExists(KeyTest::INVALID_KEY);
     }
 
     // An invalid key should not get past keyExists(), so this should never actually be possible. But we test
     // the behavior here to ensure that our method behaves correctly should the impossible ever occur.
     public function testInvalidArgumentExceptionBubblesUpFromGet()
     {
-        $key = "An invalid key";
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
-            Phake::expect($this->store, 1)->get($key)->thenThrow($exception);
+            Phake::expect($this->store, 1)->keyExists(KeyTest::INVALID_KEY)->thenReturn(true);
+            Phake::expect($this->store, 1)->get(KeyTest::INVALID_KEY)->thenThrow($exception);
         }
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyExists($key);
+        $this->assert->keyExists(KeyTest::INVALID_KEY);
     }
 
     public function testMissingKeyThrowsOutOfBoundsException()

--- a/test/Chekote/NounStore/Assert/KeyValueContainsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyValueContainsTest.php
@@ -18,101 +18,85 @@ class KeyValueContainsTest extends AssertTest
         Phake::when($this->assert)->keyValueContains(Phake::anyParameters())->thenCallParent();
     }
 
-    public function testKeyIsParsedAndParsedValuesAreUsed()
+    public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
+        $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(null);
-            Phake::expect($this->store, 1)->keyValueContains($parsedKey, $value, $parsedIndex)->thenReturn(true);
-        }
-
-        $this->assert->keyValueContains($key, $value, $index);
-    }
-
-    public function testInvalidArgumentExceptionBubblesUpFromParse()
-    {
-        $key = '10th Thing';
-        $index = 5;
-        $value = 'Some Value';
-        $exception = new InvalidArgumentException(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
-
-        /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenThrow($exception);
+        Phake::expect($this->assert, 1)->keyExists($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueContains($key, $value, $index);
+        $this->assert->keyValueContains($key, $value);
+    }
+
+    // An invalid key should not get past keyExists(), so this should never actually be possible. But we test
+    // the behavior here to ensure that our method behaves correctly should the impossible ever occur.
+    public function testInvalidArgumentExceptionBubblesUpFromKeyValueContains()
+    {
+        $key = '10th Thing';
+        $value = 'Some Value';
+        $exception = new InvalidArgumentException('Key syntax is invalid');
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        {
+            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->store, 1)->keyValueContains($key, $value)->thenThrow($exception);
+        }
+
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+
+        $this->assert->keyValueContains($key, $value);
     }
 
     public function testMissingKeyThrowsOutOfBoundsException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
         $exception = new OutOfBoundsException("Entry '$key' was not found in the store.");
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenThrow($exception);
-        }
+        Phake::expect($this->assert, 1)->keyExists($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueContains($key, $value, $index);
+        $this->assert->keyValueContains($key, $value);
     }
 
     public function testFailedMatchThrowsRuntimeException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
         $exception = new RuntimeException("Entry '$key' does not contain '$value'");
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(null);
-            Phake::expect($this->store, 1)->keyValueContains($parsedKey, $value, $parsedIndex)->thenReturn(false);
-            Phake::expect($this->key, 1)->build($parsedKey, $parsedIndex)->thenReturn($key);
+            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn(null);
+            Phake::expect($this->store, 1)->keyValueContains($key, $value)->thenReturn(false);
         }
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueContains($key, $value, $index);
+        $this->assert->keyValueContains($key, $value);
     }
 
     public function testSuccessfulMatchThrowsNoException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(null);
-            Phake::expect($this->store, 1)->keyValueContains($parsedKey, $value, $parsedIndex)->thenReturn(true);
+            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn(null);
+            Phake::expect($this->store, 1)->keyValueContains($key, $value)->thenReturn(true);
         }
 
-        $this->assert->keyValueContains($key, $value, $index);
+        $this->assert->keyValueContains($key, $value);
     }
 }

--- a/test/Chekote/NounStore/Assert/KeyValueContainsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyValueContainsTest.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore\Assert;
 
+use Chekote\NounStore\Key\KeyTest;
 use Chekote\Phake\Phake;
 use InvalidArgumentException;
 use OutOfBoundsException;
@@ -20,37 +21,35 @@ class KeyValueContainsTest extends AssertTest
 
     public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
-        $key = '10th Thing';
         $value = 'Some Value';
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->assert, 1)->keyExists($key)->thenThrow($exception);
+        Phake::expect($this->assert, 1)->keyExists(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueContains($key, $value);
+        $this->assert->keyValueContains(KeyTest::INVALID_KEY, $value);
     }
 
     // An invalid key should not get past keyExists(), so this should never actually be possible. But we test
     // the behavior here to ensure that our method behaves correctly should the impossible ever occur.
     public function testInvalidArgumentExceptionBubblesUpFromKeyValueContains()
     {
-        $key = '10th Thing';
         $value = 'Some Value';
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn(true);
-            Phake::expect($this->store, 1)->keyValueContains($key, $value)->thenThrow($exception);
+            Phake::expect($this->assert, 1)->keyExists(KeyTest::INVALID_KEY)->thenReturn(true);
+            Phake::expect($this->store, 1)->keyValueContains(KeyTest::INVALID_KEY, $value)->thenThrow($exception);
         }
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueContains($key, $value);
+        $this->assert->keyValueContains(KeyTest::INVALID_KEY, $value);
     }
 
     public function testMissingKeyThrowsOutOfBoundsException()

--- a/test/Chekote/NounStore/Assert/KeyValueIsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyValueIsTest.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore\Assert;
 
+use Chekote\NounStore\Key\KeyTest;
 use Chekote\Phake\Phake;
 use InvalidArgumentException;
 use OutOfBoundsException;
@@ -20,17 +21,16 @@ class KeyValueIsTest extends AssertTest
 
     public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
-        $key = '10th Thing';
         $value = 'Some Value';
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->assert, 1)->keyExists($key)->thenThrow($exception);
+        Phake::expect($this->assert, 1)->keyExists(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueIs($key, $value);
+        $this->assert->keyValueIs(KeyTest::INVALID_KEY, $value);
     }
 
     public function testMissingKeyThrowsOutOfBoundsException()

--- a/test/Chekote/NounStore/Assert/KeyValueIsTest.php
+++ b/test/Chekote/NounStore/Assert/KeyValueIsTest.php
@@ -18,98 +18,59 @@ class KeyValueIsTest extends AssertTest
         Phake::when($this->assert)->keyValueIs(Phake::anyParameters())->thenCallParent();
     }
 
-    public function testKeyIsParsedAndParsedValuesAreUsed()
+    public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
+        $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn($value);
-        }
-
-        $this->assert->keyValueIs($key, $value, $index);
-    }
-
-    public function testInvalidArgumentExceptionBubblesUpFromParse()
-    {
-        $key = '10th Thing';
-        $index = 5;
-        $value = 'Some Value';
-        $exception = new InvalidArgumentException(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
-
-        /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenThrow($exception);
+        Phake::expect($this->assert, 1)->keyExists($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueIs($key, $value, $index);
+        $this->assert->keyValueIs($key, $value);
     }
 
     public function testMissingKeyThrowsOutOfBoundsException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
         $exception = new OutOfBoundsException("Entry '$key' was not found in the store.");
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenThrow($exception);
-        }
+        Phake::expect($this->assert, 1)->keyExists($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueIs($key, $value, $index);
+        $this->assert->keyValueIs($key, $value);
     }
 
     public function testFailedMatchThrowsRuntimeException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
         $exception = new RuntimeException("Entry '$key' does not match '$value'");
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn('Some Other Value');
-            Phake::expect($this->key, 1)->build($parsedKey, $parsedIndex)->thenReturn($key);
-        }
+        Phake::expect($this->assert, 1)->keyExists($key)->thenReturn('Some Other Value');
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->assert->keyValueIs($key, $value, $index);
+        $this->assert->keyValueIs($key, $value);
     }
 
     public function testSuccessfulMatchThrowsNoException()
     {
         $key = '10th Thing';
-        $index = null;
-        $parsedKey = 'Thing';
-        $parsedIndex = 9;
         $value = 'Some Value';
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->assert, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn($value);
-        }
+        Phake::expect($this->assert, 1)->keyExists($key)->thenReturn($value);
 
-        $this->assert->keyValueIs($key, $value, $index);
+        $this->assert->keyValueIs($key, $value);
     }
 }

--- a/test/Chekote/NounStore/Key/KeyTest.php
+++ b/test/Chekote/NounStore/Key/KeyTest.php
@@ -7,6 +7,8 @@ use Phake_IMock;
 
 abstract class KeyTest extends TestCase
 {
+    const INVALID_KEY = "It's invalid because of the apostrophe";
+
     /** @var Key|Phake_IMock */
     protected $key;
 

--- a/test/Chekote/NounStore/Key/ParseTest.php
+++ b/test/Chekote/NounStore/Key/ParseTest.php
@@ -64,7 +64,7 @@ class ParseTest extends KeyTest
      * Tests that calling Key::parse with an invalid key throws an exception.
      *
      * @dataProvider invalidKeyDataProvider
-     * @param string $key   the key to parse
+     * @param string $key the key to parse
      */
     public function testParseKeyThrowsExceptionIfKeyAndIndexMismatch($key)
     {

--- a/test/Chekote/NounStore/Key/ParseTest.php
+++ b/test/Chekote/NounStore/Key/ParseTest.php
@@ -24,63 +24,53 @@ class ParseTest extends KeyTest
     public function successScenarioDataProvider()
     {
         return [
-        //   key           index   parsedKey,  parsedIndex
-            ['Thing',       null, 'Thing',            null], // no nth in key or index param
-            ['1st Thing',   null, 'Thing',               0], // 1st in key with no index param
-            ['1st Thing',      0, 'Thing',               0], // nth in key with matching index param
-            ['2nd Thing',   null, 'Thing',               1], // 2nd in key with no index param
-            ['3rd Thing',   null, 'Thing',               2], // 3rd in key with no index param
-            ['4th Thing',   null, 'Thing',               3], // 3th in key with no index param
-            ['478th Thing', null, 'Thing',             477], // high nth in key with no index param
-            ['Thing',          0, 'Thing',               0], // no nth in key with 0 index param
-            ['Thing',         49, 'Thing',              49], // no nth in key with high index param
+        //   key             parsedKey, parsedIndex
+            ['Thing',       'Thing',           null],
+            ['1st Thing',   'Thing',              0],
+            ['2nd Thing',   'Thing',              1],
+            ['3rd Thing',   'Thing',              2],
+            ['4th Thing',   'Thing',              3],
+            ['478th Thing', 'Thing',            477],
         ];
     }
 
     /**
-     * Tests that calling Key::parse with valid key and index combinations works correctly.
+     * Tests that calling Key::parse with valid key works correctly.
      *
      * @dataProvider successScenarioDataProvider
      * @param string $key         the key to parse
-     * @param int    $index       the index to pass along with the key
      * @param string $parsedKey   the expected resulting parsed key
      * @param int    $parsedIndex the expected resulting parsed index
      */
-    public function testSuccessScenario($key, $index, $parsedKey, $parsedIndex)
+    public function testSuccessScenario($key, $parsedKey, $parsedIndex)
     {
-        $this->assertEquals([$parsedKey, $parsedIndex], $this->key->parse($key, $index));
+        $this->assertEquals([$parsedKey, $parsedIndex], $this->key->parse($key));
     }
 
     /**
-     * Provides examples of mismatched key & index pairs.
+     * Provides examples of invalid keys.
      *
      * @return array
      */
-    public function mismatchedKeyAndIndexDataProvider()
+    public function invalidKeyDataProvider()
     {
         return [
-            ['1st Thing', 1],
-            ['1st Thing', 2],
-            ['4th Person', 0],
-            ['4th Person', 4],
-            ['4th Person', 10],
+            ["Thing's stuff"],
+            ["1st Thing's thingamajig"],
         ];
     }
 
     /**
-     * Tests that calling Key::parse with mismatched key and index param throws an exception.
+     * Tests that calling Key::parse with an invalid key throws an exception.
      *
-     * @dataProvider mismatchedKeyAndIndexDataProvider
+     * @dataProvider invalidKeyDataProvider
      * @param string $key   the key to parse
-     * @param string $index the mismatched index to pass along with the key
      */
-    public function testParseKeyThrowsExceptionIfKeyAndIndexMismatch($key, $index)
+    public function testParseKeyThrowsExceptionIfKeyAndIndexMismatch($key)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
+        $this->expectExceptionMessage('Key syntax is invalid');
 
-        $this->key->parse($key, $index);
+        $this->key->parse($key);
     }
 }

--- a/test/Chekote/NounStore/Store/GetTest.php
+++ b/test/Chekote/NounStore/Store/GetTest.php
@@ -19,81 +19,88 @@ class GetTest extends StoreTest
     public function testKeyIsParsedAndParsedValuesAreUsed()
     {
         $key = '2nd ' . StoreTest::KEY;
-        $index = null;
         $parsedKey = StoreTest::KEY;
         $parsedIndex = 1;
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(true);
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->key, 1)->parse($key)->thenReturn([$parsedKey, $parsedIndex]);
         }
 
-        $this->assertEquals(StoreTest::SECOND_VALUE, $this->store->get($key, $index));
+        $this->assertEquals(StoreTest::SECOND_VALUE, $this->store->get($key));
     }
 
-    public function testInvalidArgumentExceptionBubblesUpFromParse()
+    public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
-        $key = '10th Thing';
-        $index = 5;
-        $exception = new InvalidArgumentException(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
+        $key = "10th Thing's thingy";
+        $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenThrow($exception);
+        Phake::expect($this->store, 1)->keyExists($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->get($key, $index);
+        $this->store->get($key);
+    }
+
+    // If the Key service is behaving properly, this should never actually be possible. But we test the behavior
+    // here to ensure that our method behaves correctly should the impossible ever occur.
+    public function testInvalidArgumentExceptionBubblesUpFromParse()
+    {
+        $key = "10th Thing's thingy";
+        $exception = new InvalidArgumentException('Key syntax is invalid');
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        {
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->key, 1)->parse($key)->thenThrow($exception);
+        }
+
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+
+        $this->store->get($key);
     }
 
     public function testReturnsNullWhenKeyDoesNotExist()
     {
-        $key = StoreTest::KEY;
-        $index = 2;
-        $parsedKey = $key;
-        $parsedIndex = $index;
+        $key = '3rd ' . StoreTest::KEY;
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(false);
-        }
+        Phake::expect($this->store, 1)->keyExists($key)->thenReturn(false);
 
-        $this->assertNull($this->store->get($key, $index));
+        $this->assertNull($this->store->get($key));
     }
 
     public function testLastItemIsReturnedWhenParsedIndexIsNull()
     {
         $key = StoreTest::KEY;
-        $index = null;
         $parsedKey = $key;
-        $parsedIndex = $index;
+        $parsedIndex = null;
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(true);
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->key, 1)->parse($key)->thenReturn([$parsedKey, $parsedIndex]);
         }
 
-        $this->assertEquals(StoreTest::SECOND_VALUE, $this->store->get($key, $index));
+        $this->assertEquals(StoreTest::SECOND_VALUE, $this->store->get($key));
     }
 
     public function testIndexItemIsReturnedWhenParsedIndexIsNotNull()
     {
         $key = '1st ' . StoreTest::KEY;
-        $index = null;
         $parsedKey = StoreTest::KEY;
         $parsedIndex = 0;
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->keyExists($parsedKey, $parsedIndex)->thenReturn(true);
+            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
+            Phake::expect($this->key, 1)->parse($key)->thenReturn([$parsedKey, $parsedIndex]);
         }
 
-        $this->assertEquals(StoreTest::FIRST_VALUE, $this->store->get($key, $index));
+        $this->assertEquals(StoreTest::FIRST_VALUE, $this->store->get($key));
     }
 }

--- a/test/Chekote/NounStore/Store/GetTest.php
+++ b/test/Chekote/NounStore/Store/GetTest.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore\Store;
 
+use Chekote\NounStore\Key\KeyTest;
 use Chekote\Phake\Phake;
 use InvalidArgumentException;
 
@@ -33,35 +34,33 @@ class GetTest extends StoreTest
 
     public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
     {
-        $key = "10th Thing's thingy";
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->store, 1)->keyExists($key)->thenThrow($exception);
+        Phake::expect($this->store, 1)->keyExists(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->get($key);
+        $this->store->get(KeyTest::INVALID_KEY);
     }
 
     // If the Key service is behaving properly, this should never actually be possible. But we test the behavior
     // here to ensure that our method behaves correctly should the impossible ever occur.
     public function testInvalidArgumentExceptionBubblesUpFromParse()
     {
-        $key = "10th Thing's thingy";
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
-            Phake::expect($this->key, 1)->parse($key)->thenThrow($exception);
+            Phake::expect($this->store, 1)->keyExists(KeyTest::INVALID_KEY)->thenReturn(true);
+            Phake::expect($this->key, 1)->parse(KeyTest::INVALID_KEY)->thenThrow($exception);
         }
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->get($key);
+        $this->store->get(KeyTest::INVALID_KEY);
     }
 
     public function testReturnsNullWhenKeyDoesNotExist()

--- a/test/Chekote/NounStore/Store/KeyExistsTest.php
+++ b/test/Chekote/NounStore/Store/KeyExistsTest.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore\Store;
 
+use Chekote\NounStore\Key\KeyTest;
 use Chekote\Phake\Phake;
 use InvalidArgumentException;
 
@@ -18,16 +19,15 @@ class KeyExistsTest extends StoreTest
 
     public function testInvalidArgumentExceptionBubblesUpFromParse()
     {
-        $key = "Thing's doodle flip";
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key)->thenThrow($exception);
+        Phake::expect($this->key, 1)->parse(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->keyExists($key);
+        $this->store->keyExists(KeyTest::INVALID_KEY);
     }
 
     public function returnDataProvider()

--- a/test/Chekote/NounStore/Store/KeyExistsTest.php
+++ b/test/Chekote/NounStore/Store/KeyExistsTest.php
@@ -18,43 +18,37 @@ class KeyExistsTest extends StoreTest
 
     public function testInvalidArgumentExceptionBubblesUpFromParse()
     {
-        $key = '10th Thing';
-        $index = 5;
-        $exception = new InvalidArgumentException(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
+        $key = "Thing's doodle flip";
+        $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenThrow($exception);
+        Phake::expect($this->key, 1)->parse($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->keyExists($key, $index);
+        $this->store->keyExists($key);
     }
 
     public function returnDataProvider()
     {
         return [
-        //    key,            index, expectedResult
-            [ 'No such key',   null, false ], // missing key
-            [ StoreTest::KEY,     2, false ], // missing index
-            [ StoreTest::KEY,  null, true  ], // present key
-            [ StoreTest::KEY,     1, true  ], // present index
+        //    key,            expectedResult
+            [ 'No such key',  false ], // missing key
+            [ StoreTest::KEY, true  ], // present key
         ];
     }
 
     /**
      * @dataProvider returnDataProvider
      * @param string $key            the key to pass to keyExists, and which will be returned from the mocked parse()
-     * @param int    $index          the index to pass to KeyExists, and which will be returned from the mocked parse()
      * @param bool   $expectedResult the expected results from keyExists()
      */
-    public function testReturn($key, $index, $expectedResult)
+    public function testReturn($key, $expectedResult)
     {
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$key, $index]);
+        Phake::expect($this->key, 1)->parse($key)->thenReturn([$key, null]);
 
-        $this->assertEquals($expectedResult, $this->store->keyExists($key, $index));
+        $this->assertEquals($expectedResult, $this->store->keyExists($key));
     }
 }

--- a/test/Chekote/NounStore/Store/KeyValueContainsTest.php
+++ b/test/Chekote/NounStore/Store/KeyValueContainsTest.php
@@ -16,38 +16,18 @@ class KeyValueContainsTest extends StoreTest
         Phake::when($this->store)->keyValueContains(Phake::anyParameters())->thenCallParent();
     }
 
-    public function testKeyIsParsedAndParsedValuesAreUsed()
+    public function testInvalidArgumentExceptionBubblesUpFromGet()
     {
-        $key = '2nd ' . StoreTest::KEY;
-        $index = null;
-        $parsedKey = StoreTest::KEY;
-        $parsedIndex = 1;
-        $value = substr(self::SECOND_VALUE, 0, 2);
+        $key = "10th Thing's doodad";
+        $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn(self::SECOND_VALUE);
-        }
-
-        $this->assertTrue($this->store->keyValueContains($key, $value, $index));
-    }
-
-    public function testInvalidArgumentExceptionBubblesUpFromParse()
-    {
-        $key = '10th Thing';
-        $index = 5;
-        $exception = new InvalidArgumentException(
-            "$index was provided for index param when key '$key' contains an nth value, but they do not match"
-        );
-
-        /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key, $index)->thenThrow($exception);
+        Phake::expect($this->store, 1)->get($key)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->keyValueContains($key, "Doesn't matter", $index);
+        $this->store->keyValueContains($key, "Doesn't matter");
     }
 
     public function returnDataProvider()
@@ -68,16 +48,12 @@ class KeyValueContainsTest extends StoreTest
     public function testReturn($storedValue, $checkedValue, $expectedResult)
     {
         $key = StoreTest::KEY;
-        $index = null;
         $parsedKey = $key;
-        $parsedIndex = $index;
+        $parsedIndex = null;
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->key, 1)->parse($key, $index)->thenReturn([$parsedKey, $parsedIndex]);
-            Phake::expect($this->store, 1)->get($parsedKey, $parsedIndex)->thenReturn($storedValue);
-        }
+        Phake::expect($this->store, 1)->get($parsedKey)->thenReturn($storedValue);
 
-        $this->assertEquals($expectedResult, $this->store->keyValueContains($key, $checkedValue, $index));
+        $this->assertEquals($expectedResult, $this->store->keyValueContains($key, $checkedValue));
     }
 }

--- a/test/Chekote/NounStore/Store/KeyValueContainsTest.php
+++ b/test/Chekote/NounStore/Store/KeyValueContainsTest.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore\Store;
 
+use Chekote\NounStore\Key\KeyTest;
 use Chekote\Phake\Phake;
 use InvalidArgumentException;
 
@@ -18,16 +19,15 @@ class KeyValueContainsTest extends StoreTest
 
     public function testInvalidArgumentExceptionBubblesUpFromGet()
     {
-        $key = "10th Thing's doodad";
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->store, 1)->get($key)->thenThrow($exception);
+        Phake::expect($this->store, 1)->get(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
 
-        $this->store->keyValueContains($key, "Doesn't matter");
+        $this->store->keyValueContains(KeyTest::INVALID_KEY, "Doesn't matter");
     }
 
     public function returnDataProvider()


### PR DESCRIPTION
Use Key::build() to generate a key with the index encoded as nth instead.