### PR TITLE
Disable no_unneeded_curly_braces StyleCI check

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,6 +3,7 @@ preset: recommended
 disabled:
   - blank_line_after_opening_tag
   - concat_without_spaces
+  - no_unneeded_curly_braces
   - phpdoc_separation
   - post_increment
   - single_blank_line_before_namespace


### PR DESCRIPTION
Curly braces that StyleCI considers unneeded are actually needed to expand the scope of PHPStorm annotations beyond a single line.