### PR TITLE
Fix Scrutinizer uses wrong PHP version

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
     analysis:
       environment:
         php:
-          version: 7.1.12
+          version: 5.6.40
       project_setup:
         override:
           - 'true'


### PR DESCRIPTION
Scrutinizer is using PHP version 7.1.12, but the project's requirements are 5.6.