### PR TITLE
Switch to "dot" notation internally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": ">=5.6.30"
+        "php": ">=5.6.30",
+        "illuminate/support": "~5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,227 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b9a6a34b472e32fe3c2700672993fc8",
-    "packages": [],
+    "content-hash": "5f0fdc6e457d3d624aa01573a013129e",
+    "packages": [
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2015-11-06T14:35:42+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-08-26T23:56:53+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "~1.1",
+                "ext-mbstring": "*",
+                "illuminate/contracts": "5.4.*",
+                "paragonie/random_compat": "~1.4|~2.0",
+                "php": ">=5.6.4"
+            },
+            "replace": {
+                "tightenco/collect": "self.version"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
+                "symfony/process": "Required to use the composer class (~3.2).",
+                "symfony/var-dumper": "Required to use the dd function (~3.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                },
+                "files": [
+                    "helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-08-15T13:25:41+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2019-01-03T20:59:08+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -758,6 +974,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2016-12-08T20:27:08+00:00"
         },
         {

--- a/src/Chekote/NounStore/Key.php
+++ b/src/Chekote/NounStore/Key.php
@@ -67,17 +67,16 @@ class Key
     }
 
     /**
-     * Parses a key into the separate key and index value.
+     * Parses a key into dot-notation.
      *
-     * @example parseKey("Item"): ["Item", null]
-     * @example parseKey("1st Item"): ["Item", 0]
-     * @example parseKey("2nd Item"): ["Item", 1]
-     * @example parseKey("3rd Item"): ["Item", 2]
+     * @example parseKey("Item"): "Item"
+     * @example parseKey("1st Item"): "Item.0"
+     * @example parseKey("2nd Item"): "Item.1"
+     * @example parseKey("3rd Item"): "Item.2"
      *
      * @param  string                   $key the key to parse.
      * @throws InvalidArgumentException if the key syntax is invalid.
-     * @return array                    a tuple, the 1st being the key with the nth removed, and the 2nd being the
-     *                                      index that the nth translates to, or null if no nth was specified.
+     * @return string                   the dot-notation string.
      */
     public function parse($key)
     {
@@ -89,6 +88,6 @@ class Key
         $index = isset($matches[2]) && $matches[2] !== '' ? $matches[2] - 1 : null;
         $key = $matches[3];
 
-        return [$key, $index];
+        return $index !== null ? "$key.$index" : $key;
     }
 }

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -58,7 +58,13 @@ class Store
 
         $item = Arr::get($this->nouns, $dotPath);
 
-        return is_numeric(substr($dotPath, -1, 1)) ? $item : end($item);
+        // if the end of the dotpath references a specific instance of a noun, return it.
+        if (is_numeric(substr($dotPath, -1, 1))) {
+            return $item;
+        }
+
+        // otherwise, return the last referenced noun.
+        return is_array($item) ? end($item) : null;
     }
 
     /**

--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -1,5 +1,6 @@
 <?php namespace Chekote\NounStore;
 
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 class Store
@@ -53,13 +54,11 @@ class Store
      */
     public function get($key)
     {
-        if (!$this->keyExists($key)) {
-            return;
-        }
+        $dotPath = $this->keyService->parse($key);
 
-        list($key, $index) = $this->keyService->parse($key);
+        $item = Arr::get($this->nouns, $dotPath);
 
-        return $index !== null ? $this->nouns[$key][$index] : end($this->nouns[$key]);
+        return is_numeric(substr($dotPath, -1, 1)) ? $item : end($item);
     }
 
     /**
@@ -84,9 +83,7 @@ class Store
      */
     public function keyExists($key)
     {
-        list($key, $index) = $this->keyService->parse($key);
-
-        return $index !== null ? isset($this->nouns[$key][$index]) : isset($this->nouns[$key]);
+        return Arr::has($this->nouns, $this->keyService->parse($key));
     }
 
     /**

--- a/test/Chekote/NounStore/Assert/AssertPhake.php
+++ b/test/Chekote/NounStore/Assert/AssertPhake.php
@@ -1,0 +1,9 @@
+<?php namespace Chekote\NounStore\Assert;
+
+use Chekote\NounStore\Assert;
+use Phake_IMock;
+
+/** @mixin Assert */
+abstract class AssertPhake implements Phake_IMock
+{
+}

--- a/test/Chekote/NounStore/Assert/AssertTest.php
+++ b/test/Chekote/NounStore/Assert/AssertTest.php
@@ -2,20 +2,21 @@
 
 use Chekote\NounStore\Assert;
 use Chekote\NounStore\Key;
+use Chekote\NounStore\Key\KeyPhake;
 use Chekote\NounStore\Store;
+use Chekote\NounStore\Store\StorePhake;
 use Chekote\NounStore\TestCase;
 use Chekote\Phake\Phake;
-use Phake_IMock;
 
 abstract class AssertTest extends TestCase
 {
-    /** @var Assert|Phake_IMock */
+    /** @var AssertPhake */
     protected $assert;
 
-    /** @var Store|Phake_IMock */
+    /** @var StorePhake */
     protected $store;
 
-    /** @var Key|Phake_IMock */
+    /** @var KeyPhake */
     protected $key;
 
     /**

--- a/test/Chekote/NounStore/Key/KeyPhake.php
+++ b/test/Chekote/NounStore/Key/KeyPhake.php
@@ -1,0 +1,9 @@
+<?php namespace Chekote\NounStore\Key;
+
+use Chekote\NounStore\Key;
+use Phake_IMock;
+
+/** @mixin Key */
+abstract class KeyPhake implements Phake_IMock
+{
+}

--- a/test/Chekote/NounStore/Key/KeyTest.php
+++ b/test/Chekote/NounStore/Key/KeyTest.php
@@ -3,13 +3,12 @@
 use Chekote\NounStore\Key;
 use Chekote\NounStore\TestCase;
 use Chekote\Phake\Phake;
-use Phake_IMock;
 
 abstract class KeyTest extends TestCase
 {
     const INVALID_KEY = "It's invalid because of the apostrophe";
 
-    /** @var Key|Phake_IMock */
+    /** @var KeyPhake */
     protected $key;
 
     /**

--- a/test/Chekote/NounStore/Key/ParseTest.php
+++ b/test/Chekote/NounStore/Key/ParseTest.php
@@ -17,20 +17,20 @@ class ParseTest extends KeyTest
     }
 
     /**
-     * Provides examples of valid key and index pairs with expected parse results.
+     * Provides examples of valid key and nth pairs with expected dotPath results.
      *
      * @return array
      */
     public function successScenarioDataProvider()
     {
         return [
-            // key          parsedKey,  parsedIndex
-            ['Thing',       'Thing',           null],
-            ['1st Thing',   'Thing',              0],
-            ['2nd Thing',   'Thing',              1],
-            ['3rd Thing',   'Thing',              2],
-            ['4th Thing',   'Thing',              3],
-            ['478th Thing', 'Thing',            477],
+            // key          dotPath
+            ['Thing',       'Thing'    ],
+            ['1st Thing',   'Thing.0'  ],
+            ['2nd Thing',   'Thing.1'  ],
+            ['3rd Thing',   'Thing.2'  ],
+            ['4th Thing',   'Thing.3'  ],
+            ['478th Thing', 'Thing.477'],
         ];
     }
 
@@ -38,13 +38,12 @@ class ParseTest extends KeyTest
      * Tests that calling Key::parse with valid key works correctly.
      *
      * @dataProvider successScenarioDataProvider
-     * @param string $key         the key to parse
-     * @param string $parsedKey   the expected resulting parsed key
-     * @param int    $parsedIndex the expected resulting parsed index
+     * @param string $key     the key to parse
+     * @param string $dotPath the expected resulting dot path
      */
-    public function testSuccessScenario($key, $parsedKey, $parsedIndex)
+    public function testSuccessScenario($key, $dotPath)
     {
-        $this->assertEquals([$parsedKey, $parsedIndex], $this->key->parse($key));
+        $this->assertEquals($dotPath, $this->key->parse($key));
     }
 
     /**

--- a/test/Chekote/NounStore/Store/GetTest.php
+++ b/test/Chekote/NounStore/Store/GetTest.php
@@ -24,38 +24,17 @@ class GetTest extends StoreTest
         $parsedIndex = 1;
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
-            Phake::expect($this->key, 1)->parse($key)->thenReturn([$parsedKey, $parsedIndex]);
-        }
+        Phake::expect($this->key, 1)->parse($key)->thenReturn("$parsedKey.$parsedIndex");
 
         $this->assertEquals(StoreTest::SECOND_VALUE, $this->store->get($key));
     }
 
-    public function testInvalidArgumentExceptionBubblesUpFromKeyExists()
-    {
-        $exception = new InvalidArgumentException('Key syntax is invalid');
-
-        /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->store, 1)->keyExists(KeyTest::INVALID_KEY)->thenThrow($exception);
-
-        $this->expectException(get_class($exception));
-        $this->expectExceptionMessage($exception->getMessage());
-
-        $this->store->get(KeyTest::INVALID_KEY);
-    }
-
-    // If the Key service is behaving properly, this should never actually be possible. But we test the behavior
-    // here to ensure that our method behaves correctly should the impossible ever occur.
     public function testInvalidArgumentExceptionBubblesUpFromParse()
     {
         $exception = new InvalidArgumentException('Key syntax is invalid');
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->store, 1)->keyExists(KeyTest::INVALID_KEY)->thenReturn(true);
-            Phake::expect($this->key, 1)->parse(KeyTest::INVALID_KEY)->thenThrow($exception);
-        }
+        Phake::expect($this->key, 1)->parse(KeyTest::INVALID_KEY)->thenThrow($exception);
 
         $this->expectException(get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
@@ -66,9 +45,10 @@ class GetTest extends StoreTest
     public function testReturnsNullWhenKeyDoesNotExist()
     {
         $key = '3rd ' . StoreTest::KEY;
+        $dotPath = StoreTest::KEY . '.2';
 
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->store, 1)->keyExists($key)->thenReturn(false);
+        Phake::expect($this->key, 1)->parse($key)->thenReturn($dotPath);
 
         $this->assertNull($this->store->get($key));
     }
@@ -76,14 +56,10 @@ class GetTest extends StoreTest
     public function testLastItemIsReturnedWhenParsedIndexIsNull()
     {
         $key = StoreTest::KEY;
-        $parsedKey = $key;
-        $parsedIndex = null;
+        $dotPath = $key;
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
-            Phake::expect($this->key, 1)->parse($key)->thenReturn([$parsedKey, $parsedIndex]);
-        }
+        Phake::expect($this->key, 1)->parse($key)->thenReturn($dotPath);
 
         $this->assertEquals(StoreTest::SECOND_VALUE, $this->store->get($key));
     }
@@ -91,14 +67,10 @@ class GetTest extends StoreTest
     public function testIndexItemIsReturnedWhenParsedIndexIsNotNull()
     {
         $key = '1st ' . StoreTest::KEY;
-        $parsedKey = StoreTest::KEY;
-        $parsedIndex = 0;
+        $dotPath = StoreTest::KEY . '.0';
 
         /* @noinspection PhpUndefinedMethodInspection */
-        {
-            Phake::expect($this->store, 1)->keyExists($key)->thenReturn(true);
-            Phake::expect($this->key, 1)->parse($key)->thenReturn([$parsedKey, $parsedIndex]);
-        }
+        Phake::expect($this->key, 1)->parse($key)->thenReturn($dotPath);
 
         $this->assertEquals(StoreTest::FIRST_VALUE, $this->store->get($key));
     }

--- a/test/Chekote/NounStore/Store/KeyExistsTest.php
+++ b/test/Chekote/NounStore/Store/KeyExistsTest.php
@@ -47,7 +47,7 @@ class KeyExistsTest extends StoreTest
     public function testReturn($key, $expectedResult)
     {
         /* @noinspection PhpUndefinedMethodInspection */
-        Phake::expect($this->key, 1)->parse($key)->thenReturn([$key, null]);
+        Phake::expect($this->key, 1)->parse($key)->thenReturn($key);
 
         $this->assertEquals($expectedResult, $this->store->keyExists($key));
     }

--- a/test/Chekote/NounStore/Store/StorePhake.php
+++ b/test/Chekote/NounStore/Store/StorePhake.php
@@ -1,0 +1,9 @@
+<?php namespace Chekote\NounStore\Store;
+
+use Chekote\NounStore\Store;
+use Phake_IMock;
+
+/** @mixin Store */
+abstract class StorePhake implements Phake_IMock
+{
+}

--- a/test/Chekote/NounStore/Store/StoreTest.php
+++ b/test/Chekote/NounStore/Store/StoreTest.php
@@ -13,9 +13,9 @@ abstract class StoreTest extends TestCase
     /** @var Store|\Phake_IMock */
     protected $store;
 
-    const KEY = 'Some Key';
-    const FIRST_VALUE = 'The First Value';
-    const SECOND_VALUE = 'The Second Value';
+    const KEY = 'Color';
+    const FIRST_VALUE = 'Red';
+    const SECOND_VALUE = 'Blue';
 
     const MOST_RECENT_VALUE = self::SECOND_VALUE;
 

--- a/test/Chekote/NounStore/Store/StoreTest.php
+++ b/test/Chekote/NounStore/Store/StoreTest.php
@@ -1,16 +1,17 @@
 <?php namespace Chekote\NounStore\Store;
 
 use Chekote\NounStore\Key;
+use Chekote\NounStore\Key\KeyPhake;
 use Chekote\NounStore\Store;
 use Chekote\NounStore\TestCase;
 use Chekote\Phake\Phake;
 
 abstract class StoreTest extends TestCase
 {
-    /** @var Key|\Phake_IMock */
+    /** @var KeyPhake */
     protected $key;
 
-    /** @var Store|\Phake_IMock */
+    /** @var StorePhake */
     protected $store;
 
     const KEY = 'Color';


### PR DESCRIPTION
In preparation for more complex object graph navigation, I have switched the internal implementation to use "dot" notation for accessing the noun registry. This will make it easier to implement the complex object graph navigation going forward.