### PR TITLE
Only return recent noun for initial key segment

### DIFF
--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -54,20 +54,27 @@ class Store
      */
     public function get($key)
     {
+        $i = 0;
+
         return array_reduce(
             $this->keyService->parse($key),
-            static function ($carry, $item) {
+            static function ($carry, $item) use (&$i) {
                 list($noun, $index) = $item;
 
                 $carry = data_get($carry, $noun);
 
-                // Was a specific index requested?
-                if ($index !== null) {
-                    // Yes, fetch the specific index
-                    return data_get($carry, $index);
-                } else {
-                    // No, return the noun itself, or the latest noun if the noun is a collection
-                    return Arr::accessible($carry) ? end($carry) : $carry;
+                try {
+                    // Was a specific index requested?
+                    if ($index !== null) {
+                        // Yes, fetch the specific index
+                        return data_get($carry, $index);
+                    } else {
+                        // No, return the noun itself, or the latest noun if this is the
+                        // first component of the key, and the noun is a collection
+                        return $i === 0 && Arr::accessible($carry) ? end($carry) : $carry;
+                    }
+                } finally {
+                    ++$i;
                 }
             },
             $this->nouns

--- a/test/Integration/Chekote/NounStore/Store/GetTest.php
+++ b/test/Integration/Chekote/NounStore/Store/GetTest.php
@@ -75,15 +75,15 @@ class GetTest extends TestCase
     public function happyPathDataProvider()
     {
         return [
-            'Noun'                       => ['Person',               self::$alice,  'Alice is the most recent Person in the store'],
-            'Nth Noun'                   => ['1st Person',           self::$bob,    'Bob is the 1st Person in the store'],
-            'Related Noun'               => ["Person's car",         self::$chevy,  'Alice is the most recent Person in the store, and her most recent car is the Chevrolet'],
-            'Related Nth Noun'           => ["Person's 1st car",     self::$ford,   'Alice is the most recent Person in the store, and her 1st car is the Ford'],
-            'Nth Nouns Related Noun'     => ["1st Person's car",     self::$toyota, 'Bob is the 1st Person in the store, and his most recent car is the Toyota'],
-            'Nth Nouns Related Nth Noun' => ["1st Person's 1st car", self::$kia,    'Bob is the 1st Person in the store, and his 1st car is the Kia'],
-            'Missing Noun'               => ['Dog',                  null,          'Dog does not exist in the store'],
-            'Missing Nth Noun'           => ['3rd Person',           null,          '3rd Person does not exist in the store'],
-            'Missing Related Noun'       => ["Person's dog",         null,          'Alice is the most recent Person in the store, but has no dog'],
+            'Noun'                       => ['Person',               self::$alice,                'Alice is the most recent Person in the store'],
+            'Nth Noun'                   => ['1st Person',           self::$bob,                  'Bob is the 1st Person in the store'],
+            'Related Noun'               => ["Person's car",         [self::$ford, self::$chevy], 'Alice is the most recent Person in the store, and cars are Ford and Chevrolet'],
+            'Related Nth Noun'           => ["Person's 1st car",     self::$ford,                 'Alice is the most recent Person in the store, and her 1st car is the Ford'],
+            'Nth Nouns Related Noun'     => ["1st Person's car",     [self::$kia, self::$toyota], 'Bob is the 1st Person in the store, and his cars are Kia and Toyota'],
+            'Nth Nouns Related Nth Noun' => ["1st Person's 1st car", self::$kia,                  'Bob is the 1st Person in the store, and his 1st car is the Kia'],
+            'Missing Noun'               => ['Dog',                  null,                        'Dog does not exist in the store'],
+            'Missing Nth Noun'           => ['3rd Person',           null,                        '3rd Person does not exist in the store'],
+            'Missing Related Noun'       => ["Person's dog",         null,                        'Alice is the most recent Person in the store, but has no dog'],
         ];
     }
 

--- a/test/Unit/Chekote/NounStore/Store/GetTest.php
+++ b/test/Unit/Chekote/NounStore/Store/GetTest.php
@@ -65,8 +65,8 @@ class GetTest extends StoreTest
             'Non-existent noun returns null'                   => ['3rd ' . StoreTest::KEY,                   [[StoreTest::KEY,    2]],                   null],
             'Possessive noun w/o index string property'        => [StoreTest::KEY . "'s color",               [[StoreTest::KEY, null], ['color', null]],  'Blue'],
             'Possessive noun with index string property'       => ['1st ' . StoreTest::KEY . "'s color",      [[StoreTest::KEY, 0], ['color', null]],     'Red'],
-            'Possessive noun w/o index collection w/o index'   => [StoreTest::KEY . "'s option",              [[StoreTest::KEY, null], ['option', null]], 'Air Conditioning'],
-            'Possessive noun with index collection w/o index'  => ['1st ' . StoreTest::KEY . "'s option",     [[StoreTest::KEY, 0], ['option', null]],    'Heated Seats'],
+            'Possessive noun w/o index collection w/o index'   => [StoreTest::KEY . "'s option",              [[StoreTest::KEY, null], ['option', null]], ['Cruise Control', 'Air Conditioning']],
+            'Possessive noun with index collection w/o index'  => ['1st ' . StoreTest::KEY . "'s option",     [[StoreTest::KEY, 0], ['option', null]],    ['GPS', 'Heated Seats']],
             'Possessive noun w/o index collection with index'  => [StoreTest::KEY . "'s 1st option",          [[StoreTest::KEY, null], ['option', 0]],    'Cruise Control'],
             'Possessive noun with index collection with index' => ['1st ' . StoreTest::KEY . "'s 1st option", [[StoreTest::KEY, 0], ['option', 0]],       'GPS'],
         ];


### PR DESCRIPTION
## Problem
The intended use case of the noun store is to keep track of recently referenced nouns, that is why the most recent noun is returned. So if you continually reference and store users in the noun store, when you make a statement like "And the User can access the secure portal", the noun "User" is referring to the most recent user that you referenced, just as would be the case in normal English language.

A problem arose when this logic was extended to the recently implemented complex noun navigation, where if any noun in the key was array like, and no nth was specified, then the most recent entry would be returned.

### Simple key example (one segment):
If you asked for "Person", and there were three people stored under that key, you would get the most recent person, rather than the entire "Person" collection.

### Complex key example (multiple segments):
If you asked for "Person's car", and "car" was a collection of cars, you would get the most recent car, rather than the entire "car" collection.

This caused a problem with Laravel models because they *are* array-like. So when you wanted to a relationship from the store, for example, a customers address, and the Customer Model had a relationship to an Address model, the noun store would see that you asked for "Customer's address", fetch the "address" relationship, see that it was array-like and return the "end" of it instead of the entire object.

Given the intended use case of the noun store, it really makes no sense for any noun other than the first entry in the key to return the "end", so I have modified the behavior to do just that:

## Modified behavior:

### Simple key example (one segment):
If you asked for "Person", and there were three people stored under that key, you would get the most recent person, rather than the entire "Person" collection (because "Person" is the first part of the key).

### Complex key example (multiple segments):
If you asked for "Person's car", and car was a collection of cars, you will get the entire collection of cars. Since "car" is not the first segment of the key, the noun store will not return the "end" of it.