### PR TITLE
Return values after assert in keyValueContains & keyIsClass

### DIFF
--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -55,19 +55,21 @@ class Assert
      *
      * @see    Key::build()
      * @see    Key::parseNoun()
-     * @param  string                   $key   The key to check. Supports nth notation.
-     * @param  string                   $value The value expected to be contained within the key's value.
+     * @param  string                   $key    The key to check. Supports nth notation.
+     * @param  string                   $needle The value expected to be contained within the key's value.
      * @throws OutOfBoundsException     If a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
      *                                  that does not match the index.
      */
-    public function keyValueContains($key, $value)
+    public function keyValueContains($key, $needle)
     {
-        $this->keyExists($key);
+        $haystack = $this->keyExists($key);
 
-        if (!$this->store->keyValueContains($key, $value)) {
-            throw new RuntimeException("Entry '$key' does not contain '$value'");
+        if (!$this->store->keyValueContains($key, $needle)) {
+            throw new RuntimeException("Entry '$key' does not contain '$needle'");
         }
+
+        return $haystack;
     }
 
     /**

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -98,11 +98,14 @@ class Assert
      * @param  string               $key   The key to check. Supports nth notation.
      * @param  string               $class The expected class instance.
      * @throws OutOfBoundsException If a value has not been stored for the specified key.
+     * @return mixed                The key's value.
      */
     public function keyIsClass($key, $class)
     {
         if ($this->keyExists($key) && !$this->store->keyIsClass($key, $class)) {
             throw new RuntimeException("Entry '$key' does not match instance of '$class'");
         }
+
+        return $this->store->get($key);
     }
 }

--- a/src/Chekote/NounStore/Key.php
+++ b/src/Chekote/NounStore/Key.php
@@ -38,7 +38,7 @@ class Key
      * @param  int|null                 $index The index (zero indexed) value for the key. If not specified, the method
      *                                         will not add an index notation to the key.
      * @throws InvalidArgumentException if $index is less than -1. Note: It should really be zero or higher, but this
-     *                                        method does not assert that. The error is bubbling up from getOrdinal()
+     *                                  method does not assert that. The error is bubbling up from getOrdinal()
      * @return string                   the key with the index, or just the key if index is null.
      */
     public function build($key, $index)
@@ -80,8 +80,8 @@ class Key
      * @param  string                   $key the key to parse.
      * @throws InvalidArgumentException if the key syntax is invalid.
      * @return array[]                  a array of tuples. With each tuple have the noun with the nth removed as the
-     *                                      1st item, and the index that the nth translates to as the 2nd or null if no
-     *                                      nth was specified.
+     *                                  1st item, and the index that the nth translates to as the 2nd or null if no
+     *                                  nth was specified.
      */
     public function parse($key)
     {
@@ -99,7 +99,7 @@ class Key
      * @param  string                   $noun the key to parse.
      * @throws InvalidArgumentException if the key syntax is invalid.
      * @return array                    a tuple, the 1st being the key with the nth removed, and the 2nd being the
-     *                                       index that the nth translates to, or null if no nth was specified.
+     *                                  index that the nth translates to, or null if no nth was specified.
      */
     protected function parseNoun($noun)
     {

--- a/test/Unit/Chekote/NounStore/Assert/KeyIsClassTest.php
+++ b/test/Unit/Chekote/NounStore/Assert/KeyIsClassTest.php
@@ -90,13 +90,31 @@ class KeyIsClassTest extends AssertTest
     {
         $key = '15th Thing';
         $value = stdClass::class;
+        $instance = new $value();
 
         /* @noinspection PhpUndefinedMethodInspection */
         {
-            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn(new $value());
+            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn($instance);
             Phake::expect($this->store, 1)->keyIsClass($key, $value)->thenReturn(true);
+            Phake::expect($this->store, 1)->get($key)->thenReturn($instance);
         }
 
         $this->assert->keyIsClass($key, $value);
+    }
+
+    public function testSuccessfulMatchReturnsValue()
+    {
+        $key = '16th Thing';
+        $value = stdClass::class;
+        $instance = new $value();
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        {
+            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn($instance);
+            Phake::expect($this->store, 1)->keyIsClass($key, $value)->thenReturn(true);
+            Phake::expect($this->store, 1)->get($key)->thenReturn($instance);
+        }
+
+        $this->assertSame($instance, $this->assert->keyIsClass($key, $value));
     }
 }

--- a/test/Unit/Chekote/NounStore/Assert/KeyValueContainsTest.php
+++ b/test/Unit/Chekote/NounStore/Assert/KeyValueContainsTest.php
@@ -98,4 +98,18 @@ class KeyValueContainsTest extends AssertTest
 
         $this->assert->keyValueContains($key, $value);
     }
+
+    public function testSuccessfulMatchReturnsValue()
+    {
+        $key = '16th Thing';
+        $value = 'Raspberry';
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        {
+            Phake::expect($this->assert, 1)->keyExists($key)->thenReturn($value);
+            Phake::expect($this->store, 1)->keyValueContains($key, $value)->thenReturn(true);
+        }
+
+        $this->assertSame($value, $this->assert->keyValueContains($key, $value));
+    }
 }


### PR DESCRIPTION
## Problem
Sometimes callers want to perform actions with the values from these keys after making a successfull assertion. This is currently not possible since the values are not returned.

## Fix
Return the values from these methods after a successful assertions.

## Change Log
- **Add test for return value of keyValueContains()**
- **Make keyValueContains() return the value for the key**
- **Add test for return value of keyIsClass()**
- **Make keyIsClass() return the value for the key**
