### PR TITLE
Use dedicated exceptions instead of generic ones

### DIFF
--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -57,6 +57,7 @@ class Assert
      * @see    Key::parseNoun()
      * @param  string                   $key    The key to check. Supports nth notation.
      * @param  string                   $needle The value expected to be contained within the key's value.
+     * @throws AssertionFailedException If the key's value does not contain the specified string.
      * @throws OutOfBoundsException     If a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
      *                                  that does not match the index.
@@ -66,7 +67,7 @@ class Assert
         $haystack = $this->keyExists($key);
 
         if (!$this->store->keyValueContains($key, $needle)) {
-            throw new RuntimeException("Entry '$key' does not contain '$needle'");
+            throw new AssertionFailedException("Entry '$key' does not contain '$needle'");
         }
 
         return $haystack;

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -80,6 +80,7 @@ class Assert
      * @see    Key::parseNoun()
      * @param  string                   $key   The key to check. Supports nth notation.
      * @param  mixed                    $value The expected value.
+     * @throws AssertionFailedException If the key's value does not match the specified value.
      * @throws OutOfBoundsException     If a value has not been stored for the specified key.
      * @throws InvalidArgumentException if both an $index and $key are provided, but the $key contains an nth value
      *                                  that does not match the index.
@@ -87,7 +88,7 @@ class Assert
     public function keyValueIs($key, $value)
     {
         if ($this->keyExists($key) != $value) {
-            throw new RuntimeException("Entry '$key' does not match '" . print_r($value, true) . "'");
+            throw new AssertionFailedException("Entry '$key' does not match '" . print_r($value, true) . "'");
         }
     }
 

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -2,7 +2,6 @@
 
 use InvalidArgumentException;
 use OutOfBoundsException;
-use RuntimeException;
 
 /**
  * Makes assertions regarding store data.
@@ -97,15 +96,16 @@ class Assert
      *
      * @see    Key::build()
      * @see    Key::parseNoun()
-     * @param  string               $key   The key to check. Supports nth notation.
-     * @param  string               $class The expected class instance.
-     * @throws OutOfBoundsException If a value has not been stored for the specified key.
-     * @return mixed                The key's value.
+     * @param  string                   $key   The key to check. Supports nth notation.
+     * @param  string                   $class The expected class instance.
+     * @throws AssertionFailedException If the key's value is not an instance of the specified class.
+     * @throws OutOfBoundsException     If a value has not been stored for the specified key.
+     * @return mixed                    The key's value.
      */
     public function keyIsClass($key, $class)
     {
         if ($this->keyExists($key) && !$this->store->keyIsClass($key, $class)) {
-            throw new RuntimeException("Entry '$key' does not match instance of '$class'");
+            throw new AssertionFailedException("Entry '$key' does not match instance of '$class'");
         }
 
         return $this->store->get($key);

--- a/src/Chekote/NounStore/AssertionFailedException.php
+++ b/src/Chekote/NounStore/AssertionFailedException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Chekote\NounStore;
+
+use RuntimeException;
+
+class AssertionFailedException extends RuntimeException
+{
+}

--- a/test/Unit/Chekote/NounStore/Assert/KeyIsClassTest.php
+++ b/test/Unit/Chekote/NounStore/Assert/KeyIsClassTest.php
@@ -1,8 +1,8 @@
 <?php namespace Unit\Chekote\NounStore\Assert;
 
+use Chekote\NounStore\AssertionFailedException;
 use InvalidArgumentException;
 use OutOfBoundsException;
-use RuntimeException;
 use stdClass;
 use Unit\Chekote\NounStore\Key\KeyTest;
 use Unit\Chekote\Phake\Phake;
@@ -71,7 +71,7 @@ class KeyIsClassTest extends AssertTest
     {
         $key = '14th Thing';
         $value = stdClass::class;
-        $exception = new RuntimeException("Entry '$key' does not match instance of '$value'");
+        $exception = new AssertionFailedException("Entry '$key' does not match instance of '$value'");
         $randomClass = $this;
 
         /* @noinspection PhpUndefinedMethodInspection */

--- a/test/Unit/Chekote/NounStore/Assert/KeyValueContainsTest.php
+++ b/test/Unit/Chekote/NounStore/Assert/KeyValueContainsTest.php
@@ -1,8 +1,8 @@
 <?php namespace Unit\Chekote\NounStore\Assert;
 
+use Chekote\NounStore\AssertionFailedException;
 use InvalidArgumentException;
 use OutOfBoundsException;
-use RuntimeException;
 use Unit\Chekote\NounStore\Key\KeyTest;
 use Unit\Chekote\Phake\Phake;
 
@@ -71,7 +71,7 @@ class KeyValueContainsTest extends AssertTest
     {
         $key = '14th Thing';
         $value = 'Strawberry';
-        $exception = new RuntimeException("Entry '$key' does not contain '$value'");
+        $exception = new AssertionFailedException("Entry '$key' does not contain '$value'");
 
         /* @noinspection PhpUndefinedMethodInspection */
         {

--- a/test/Unit/Chekote/NounStore/Assert/KeyValueIsTest.php
+++ b/test/Unit/Chekote/NounStore/Assert/KeyValueIsTest.php
@@ -1,8 +1,8 @@
 <?php namespace Unit\Chekote\NounStore\Assert;
 
+use Chekote\NounStore\AssertionFailedException;
 use InvalidArgumentException;
 use OutOfBoundsException;
-use RuntimeException;
 use Unit\Chekote\NounStore\Key\KeyTest;
 use Unit\Chekote\Phake\Phake;
 
@@ -52,7 +52,7 @@ class KeyValueIsTest extends AssertTest
     {
         $key = '17th Thing';
         $value = 'Orange';
-        $exception = new RuntimeException("Entry '$key' does not match '$value'");
+        $exception = new AssertionFailedException("Entry '$key' does not match '$value'");
 
         /* @noinspection PhpUndefinedMethodInspection */
         Phake::expect($this->assert, 1)->keyExists($key)->thenReturn('Some Other Value');


### PR DESCRIPTION
## Change Notes
- **Create AssertionFailedException**
- **Use AssertionFailedException in Assert::keyValueContains()**
- **Use AssertionFailedException in Assert::keyValueIs()**
- **Use AssertionFailedException in Assert::keyIsClass()**
