### PR TITLE
Use concise character class syntax '\d' instead of '[0-9]'

### DIFF
--- a/src/Chekote/NounStore/Key.php
+++ b/src/Chekote/NounStore/Key.php
@@ -103,7 +103,7 @@ class Key
      */
     protected function parseNoun($noun)
     {
-        if (!preg_match("/^(([1-9][0-9]*)(?:st|nd|rd|th) )?([^']+)$/", $noun, $matches)) {
+        if (!preg_match("/^(([1-9]\d*)(?:st|nd|rd|th) )?([^']+)$/", $noun, $matches)) {
             throw new InvalidArgumentException('Key syntax is invalid');
         }
 

--- a/test/Unit/Chekote/NounStore/Key/ParseNounTest.php
+++ b/test/Unit/Chekote/NounStore/Key/ParseNounTest.php
@@ -30,6 +30,7 @@ class ParseNounTest extends KeyTest
             ['2nd Thing',   'Thing',              1],
             ['3rd Thing',   'Thing',              2],
             ['4th Thing',   'Thing',              3],
+            ['10th Thing',  'Thing',              9],
             ['478th Thing', 'Thing',            477],
         ];
     }


### PR DESCRIPTION
## Change Log
- **Ensure parseNoun() supports 0 for the 2nd nth digit (TDD)**
- **Use concise character class syntax '\d' instead of '[0-9]'.**
