### PR TITLE
Update docblock to specify return type based on parameter.

### DIFF
--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -96,11 +96,11 @@ class Assert
      * @template T
      * @see      Key::build()
      * @see      Key::parseNoun()
-     * @param    string                   $key   The key to check. Supports nth notation.
-     * @param    class-string<T>          $class The expected class instance.
-     * @throws   AssertionFailedException If the key's value is not an instance of the specified class.
-     * @throws   OutOfBoundsException     If a value has not been stored for the specified key.
-     * @return   T                        The key's value.
+     * @param  string                   $key   The key to check. Supports nth notation.
+     * @param  class-string<T>          $class The expected class instance.
+     * @throws AssertionFailedException If the key's value is not an instance of the specified class.
+     * @throws OutOfBoundsException     If a value has not been stored for the specified key.
+     * @return T                        The key's value.
      */
     public function keyIsClass(string $key, string $class): mixed
     {

--- a/src/Chekote/NounStore/Assert.php
+++ b/src/Chekote/NounStore/Assert.php
@@ -93,13 +93,14 @@ class Assert
     /**
      * Asserts that the key's value matches the specified class instance.
      *
-     * @see    Key::build()
-     * @see    Key::parseNoun()
-     * @param  string                   $key   The key to check. Supports nth notation.
-     * @param  class-string             $class The expected class instance.
-     * @throws AssertionFailedException If the key's value is not an instance of the specified class.
-     * @throws OutOfBoundsException     If a value has not been stored for the specified key.
-     * @return mixed                    The key's value.
+     * @template T
+     * @see      Key::build()
+     * @see      Key::parseNoun()
+     * @param    string                   $key   The key to check. Supports nth notation.
+     * @param    class-string<T>          $class The expected class instance.
+     * @throws   AssertionFailedException If the key's value is not an instance of the specified class.
+     * @throws   OutOfBoundsException     If a value has not been stored for the specified key.
+     * @return   T                        The key's value.
      */
     public function keyIsClass(string $key, string $class): mixed
     {


### PR DESCRIPTION
Provides type to IDE so it better understand the return value

Source: https://psalm.dev/docs/annotating_code/templated_annotations/#param-class-stringt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated PHPDoc comments for improved clarity on method parameters and return types.
  
- **New Features**
	- Enhanced type safety for the `keyIsClass` method, ensuring it works with specific class types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->