### PR TITLE
Fix error when reading from empty store

### DIFF
--- a/src/Chekote/NounStore/Store.php
+++ b/src/Chekote/NounStore/Store.php
@@ -7,7 +7,7 @@ class Store
 {
     protected Key $keyService;
 
-    protected array $nouns;
+    protected array $nouns = [];
 
     /**
      * @param Key|null $keyService the key service to use for parsing and building keys

--- a/test/Unit/Chekote/NounStore/Store/GetTest.php
+++ b/test/Unit/Chekote/NounStore/Store/GetTest.php
@@ -29,6 +29,17 @@ class GetTest extends StoreTestCase
         $this->assertEquals(StoreTestCase::$secondValue, $this->store->get($key));
     }
 
+    public function testReturnsNullWhenStoreIsEmpty(): void
+    {
+        /* @noinspection PhpUndefinedMethodInspection */
+        Phake::expect($this->key, 1)->parse(StoreTestCase::KEY)->thenReturn([[StoreTestCase::KEY, null]]);
+
+        /* @noinspection PhpUndefinedFieldInspection */
+        Phake::makeVisible($this->store)->nouns = [];
+
+        $this->assertNull($this->store->get(StoreTestCase::KEY));
+    }
+
     public function testInvalidArgumentExceptionBubblesUpFromParse()
     {
         $exception = new InvalidArgumentException('Key syntax is invalid');

--- a/test/Unit/Chekote/NounStore/Store/GetTest.php
+++ b/test/Unit/Chekote/NounStore/Store/GetTest.php
@@ -1,6 +1,8 @@
 <?php namespace Unit\Chekote\NounStore\Store;
 
+use Chekote\NounStore\Store;
 use InvalidArgumentException;
+use Phake\IMock;
 use Unit\Chekote\NounStore\Key\KeyTestCase;
 use Unit\Chekote\Phake\Phake;
 
@@ -31,13 +33,16 @@ class GetTest extends StoreTestCase
 
     public function testReturnsNullWhenStoreIsEmpty(): void
     {
+        /** @var IMock|StorePhake $store */
+        $store = Phake::strictMockWithConstructor(Store::class, $this->key);
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        Phake::when($store)->get(Phake::anyParameters())->thenCallParent();
+
         /* @noinspection PhpUndefinedMethodInspection */
         Phake::expect($this->key, 1)->parse(StoreTestCase::KEY)->thenReturn([[StoreTestCase::KEY, null]]);
 
-        /* @noinspection PhpUndefinedFieldInspection */
-        Phake::makeVisible($this->store)->nouns = [];
-
-        $this->assertNull($this->store->get(StoreTestCase::KEY));
+        $this->assertNull($store->get(StoreTestCase::KEY));
     }
 
     public function testInvalidArgumentExceptionBubblesUpFromParse()


### PR DESCRIPTION
**Problem:**

Attempting to get a value from the Store without first setting a value raises a PHP error: Typed property Store::$nouns must not be accessed before initialization

This can be easily reproduced by running the following code:

```php
$store = new Store();
$store->get('anything');
```

**Cause:**

The $nouns property does not have a default value, so it cannot be accessed before it is written to.

When we set any noun using the `set` method, PHP automatically initializes the array, which prevents the error from happening from then on.

**Solution:**

The solution is to give the property a default value, ensuring it's always initialized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when reading from an uninitialized noun store by initializing it to an empty collection.

* **Tests**
  * Added test validating that retrieval returns null when the store is empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chekote/noun-store/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->