### PR TITLE
Loosen illuminate/support dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "require": {
         "php": ">=8.1",
-        "illuminate/support": "^5.0"
+        "illuminate/support": ">=5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
Every major version of Laravel is locked to a corresponding major version of illuminate/support.

The current constraint is more restrictive than necessary and limits the package’s use to applications running Laravel 5, even though it is compatible with newer Laravel versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to support a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->